### PR TITLE
Fix | Package Autoload Typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,7 @@
     },
     "autoload": {
         "psr-4": {
-            "aloware\\CursorPagination\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "aloware\\CursorPagination\\Tests\\": "tests/"
+            "Aloware\\CursorPagination\\": "src/"
         }
     },
     "extra": {


### PR DESCRIPTION
Package autoload in `composer.json` file had a typo.
It fixed now